### PR TITLE
Use fallback editor if $EDITOR undefined

### DIFF
--- a/notes
+++ b/notes
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+EDITOR=${EDITOR:-editor}
+
 configured_dir=${NOTES_DIRECTORY%/} # Remove trailing slashes
 notes_dir="${configured_dir:-$HOME/notes}"
 escaped_notes_dir=$(printf $notes_dir | sed -e 's/[]\/$*.^|[]/\\&/g')


### PR DESCRIPTION
Apparently I did not have `$EDITOR` set, however debian based systems have the `editor` symlink. This caused issues for me when trying to create a new note:

    $ ./notes new test
    ./notes: line 71: /home/user/notes/test.md: No such file or directory

This PR thus uses that binary in case $EDITOR is unset.

Edit: because of issue #2 I don't know how to add a test-case for this :(