### PR TITLE
Bash shebang via /usr/bin/env

### DIFF
--- a/notes
+++ b/notes
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 configured_dir=${NOTES_DIRECTORY%/} # Remove trailing slashes
 notes_dir="${configured_dir:-$HOME/notes}"


### PR DESCRIPTION
Instead of relying bash be under /bin/bash (BSD systems are different), use `/usr/bin/env bash` instead.