### PR TITLE
Allow user to specify different editor for `notes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This demo uses zsh, vim and dropbox, but don't panic, that's just me. `notes` wi
 
 You already have a tool that backs up and syncs your data (be it Dropbox, iCloud, Seafile or whatever). You already have a text editor on your desktop, your laptops, your phone and that tablet you've forgotten about.
 
-You want to take notes. 
+You want to take notes.
 
 You could use a web X.0 note taking app that reimplements all of that from scratch (poorly). You could tie yourself to a tool that holds all your data for you in its own brand-new format, locks you into its (often bloated) UI, and then steadily removes features unless you start paying (hey Evernote). You don't have to.
 
@@ -49,7 +49,7 @@ Opens your notes folder in your default configured file explorer. Shorthand alia
 
 ### `notes open <note-name>`
 
-Opens a given note in your `$EDITOR`. Name can be an absolute path, or a relative path in your notes (.md suffix optional). Shorthand alias also available with `notes o`.
+Opens a given note in your `$EDITOR` (`$NOTES_EDITOR` instead if it exists). Name can be an absolute path, or a relative path in your notes (.md suffix optional). Shorthand alias also available with `notes o`.
 
 ### `notes grep/find <pattern> | notes open`
 

--- a/notes
+++ b/notes
@@ -4,13 +4,16 @@ configured_dir=${NOTES_DIRECTORY%/} # Remove trailing slashes
 notes_dir="${configured_dir:-$HOME/notes}"
 escaped_notes_dir=$(printf $notes_dir | sed -e 's/[]\/$*.^|[]/\\&/g')
 
-# If no $EDITOR, look for `editor` (symlink on debian/ubuntu/etc)
-if [ -z "$EDITOR" ] && type editor &>/dev/null; then
+if [ "$NOTES_EDITOR" ]; then
+    # Allow user to specify separate editor specifically for notes
+    EDITOR="$NOTES_EDITOR"
+elif [ -z "$EDITOR" ] && type editor &>/dev/null; then
+    # If no $EDITOR, look for `editor` (symlink on debian/ubuntu/etc)
     EDITOR=editor
 fi
 
 without_notes_dir() {
-    cat | sed -e s/^$escaped_notes_dir//g | sed -E "s/^\/+//g" 
+    cat | sed -e s/^$escaped_notes_dir//g | sed -E "s/^\/+//g"
 }
 
 find_notes() {


### PR DESCRIPTION
Check `$NOTES_EDITOR` first and use it instead of `$EDITOR` if it exists.

In case users want to use a special markdown editor for `notes` for example instead of the usual `$EDITOR`.