### PR TITLE
Add `ls` alias for `find`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ By default your notes live in ~/notes, but you can change that to anywhere you l
 
 Opens your `$EDITOR` of choice for a new note, with the given name. The name can include slashes, if you want to put your note in a subfolder. Shorthand alias also available with `notes n`.
 
+### `notes ls`
+
+Lists all notes (same as `notes find` with no arguments)
+
 ### `notes find <part-of-a-note-name>`
 
 Searches note filenames and paths for the given string, and returns all the matches. Shorthand alias also available with `notes f`.

--- a/notes
+++ b/notes
@@ -86,6 +86,7 @@ notes is a command line note taking tool.
 
 Usage:
     notes new|n <name>                    # Create a new note
+    notes ls                              # List all notes
     notes find|f [pattern]                # Search notes by filename and path
     notes grep|g <pattern>                # Search notes by content
     notes open|o                          # Open your notes directory

--- a/notes
+++ b/notes
@@ -10,7 +10,7 @@ if [ -z "$EDITOR" ] && type editor &>/dev/null; then
 fi
 
 without_notes_dir() {
-    cat | sed -e s/^$escaped_notes_dir//g | sed -E "s/^\/+//g" 
+    cat | sed -e s/^$escaped_notes_dir//g | sed -E "s/^\/+//g"
 }
 
 find_notes() {
@@ -114,7 +114,7 @@ main() {
         "new"|"n" )
             cmd="new_note"
             ;;
-        "find"|"f" )
+        "find"|"f"|"ls" )
             cmd="find_notes"
             ;;
         "grep"|"g" )


### PR DESCRIPTION
After creating a note the first thing I tried to do was run `notes ls` to show all of my existing ones, and was a little confused as to what command I was supposed to run instead.

While this means you can search with it as well, which isn't technically fully correct, it seems like a harmless alias.