### PR TITLE
Add combined grep/find as search

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Searches all note content for the given string and returns all the matches. Shor
 
 Lists note names and note directories at a single level. Lists all top level notes and directories if no path is provided, or the top-level contents of a directory if one is provided.
 
+### `notes search <part-of-a-note-name-or-note-content>`
+
+Searches all note content and note filenames for the given string and returns all the matches. Shorthand alias also available with `notes s`.
+
 ### `notes open`
 
 Opens your notes folder in your default configured file explorer. Shorthand alias also available with `notes o`.
@@ -91,7 +95,7 @@ Combine these together! This opens each matching note in your `$EDITOR` in turn.
 
 All the above works. Here's what's coming next:
 
-- [ ] Combining find and grep, to match either one (https://github.com/pimterry/notes/issues/16)
+- [x] Combining find and grep, to match either one (https://github.com/pimterry/notes/issues/16)
 - [ ] More interesting and nicer looking file/grep search result formatting, perhaps only when not piping? (https://github.com/pimterry/notes/issues/27)
 - [ ] Make the file extension optional (https://github.com/pimterry/notes/issues/24)
 - [ ] zsh command and note name autocompletion (https://github.com/pimterry/notes/issues/25)

--- a/notes
+++ b/notes
@@ -182,7 +182,11 @@ main() {
             ;;
         "ls" )
             cmd="ls_notes"
-        "search"|"s")
+            ;;
+        "search"|"s" )
+            cmd="search_filenames_and_contents"
+            ;;
+        "search"|"s" )
             cmd="search_filenames_and_contents"
             ;;
         "find"|"f" )

--- a/notes
+++ b/notes
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Look for configuration file at ~/.config/notes/config and use it
-if [ -f ~/.config/notes/config ]; then 
+if [ -f ~/.config/notes/config ]; then
     . ~/.config/notes/config
 fi
 
@@ -31,6 +31,28 @@ ls_notes() {
     fi
 
     if [[ $ls_result == 0 && "$formatted_output" ]]; then
+        printf "$formatted_output\n"
+        return 0
+    else
+        return 2
+    fi
+}
+
+search_filenames_and_contents() {
+    if [ "$#" -gt 0 ]; then
+        find_output=$(find "$notes_dir" -type f -exec bash -c \
+            "shopt -s nocasematch
+            grep -il \"$*\" {} || if [[ \"{}\" =~ \"$*\" ]]; then
+                echo {};
+            fi" \;\
+        )
+    else
+        find_output=$(find "$notes_dir" -type f)
+    fi
+    find_result=$?
+    formatted_output=$(printf "$find_output" | without_notes_dir)
+
+    if [[ $find_result == 0 && "$formatted_output" ]]; then
         printf "$formatted_output\n"
         return 0
     else
@@ -130,6 +152,7 @@ Usage:
     notes ls <pattern>                    # List notes by path
     notes find|f [pattern]                # Search notes by filename and path
     notes grep|g <pattern>                # Search notes by content
+    notes search|s [pattern]              # Search notes by filename or content
     notes open|o                          # Open your notes directory
     notes open|o <name>                   # Open a note for editing by full name
     notes rm [-r | --recursive] <name>    # Remove note, or folder if -r or --recursive is given
@@ -159,6 +182,8 @@ main() {
             ;;
         "ls" )
             cmd="ls_notes"
+        "search"|"s")
+            cmd="search_filenames_and_contents"
             ;;
         "find"|"f" )
             cmd="find_notes"

--- a/test/test-search.bats
+++ b/test/test-search.bats
@@ -1,0 +1,115 @@
+#!./libs/bats/bin/bats
+
+load 'libs/bats-support/load'
+load 'libs/bats-assert/load'
+load 'helpers'
+
+setup() {
+  setupNotesEnv
+}
+
+teardown() {
+  teardownNotesEnv
+}
+
+notes="./notes"
+
+@test "Should output nothing and return non-zero if there are no notes to search" {
+  run $notes search
+
+  assert_failure
+  echo $output
+  assert_equal $(echo $output | wc -w) 0
+}
+
+@test "Should show all notes found if no pattern is provided to search" {
+  touch $NOTES_DIRECTORY/note1.md
+  touch $NOTES_DIRECTORY/note2.md
+
+  run $notes search
+  assert_success
+  assert_line "note1.md"
+  assert_line "note2.md"
+}
+
+@test "Should search notes when using the search shorthand alias" {
+  touch $NOTES_DIRECTORY/note.md
+
+  run $notes s
+  assert_success
+  assert_line "note.md"
+}
+
+@test "Should show matching notes only if a pattern is provided to search" {
+  touch $NOTES_DIRECTORY/match-note1.md
+  touch $NOTES_DIRECTORY/hide-note2.md
+
+  run $notes search "match"
+
+  assert_success
+  assert_line "match-note1.md"
+  refute_line "hide-note2.md"
+}
+
+@test "Should match notes case insensitively with search" {
+  touch $NOTES_DIRECTORY/MATCH-note1.md
+  touch $NOTES_DIRECTORY/hide-note2.md
+
+  run $notes search "match"
+
+  assert_success
+  assert_line "MATCH-note1.md"
+  refute_line "hide-note2.md"
+}
+
+@test "Should match subdirectory or file names with search" {
+  touch "$NOTES_DIRECTORY/hide-note.md"
+  mkdir "$NOTES_DIRECTORY/match-directory"
+  touch "$NOTES_DIRECTORY/match-directory/note.md"
+
+  run $notes search "match"
+
+  assert_success
+  assert_output "match-directory/note.md"
+}
+
+@test "Should search files inside subdirectories with spaces" {
+  mkdir "$NOTES_DIRECTORY/path with spaces"
+  touch "$NOTES_DIRECTORY/path with spaces/note.md"
+
+  run $notes search
+
+  assert_success
+  assert_output "path with spaces/note.md"
+}
+
+# These are the 'grep' tests.
+
+@test "Should match only the files containing the given pattern when searching" {
+  echo "my-pattern" > $NOTES_DIRECTORY/matching-note.md
+  echo "some-other-pattern" > $NOTES_DIRECTORY/non-matching-note.md
+
+  run $notes search my-pattern
+
+  assert_success
+  assert_line "matching-note.md"
+  refute_line "non-matching-note.md"
+}
+
+@test "Should search notes when using the search shorthand alias" {
+  echo "my-pattern" > $NOTES_DIRECTORY/matching-note.md
+
+  run $notes s my-pattern
+
+  assert_success
+  assert_line "matching-note.md"
+}
+
+@test "Should search case-insensitively" {
+  echo "LETTERS" > $NOTES_DIRECTORY/matching-note.md
+
+  run $notes search letter
+
+  assert_success
+  assert_line "matching-note.md"
+}


### PR DESCRIPTION
Here's a rough implementation of a combining grep/find together, so that you can search for files based on filename or contents. Performance might be better if we ran the grep and find separately and then sorted/uniq'd the results together, but this solution works.

I did run the tests and threw together a new test-search.bats based on the others. I called this functionality 'search' as I wasn't sure whether you wanted this to replace existing functionality or not.