### PR TITLE
Fix Makefile and don't overwrite config file if already present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,21 +14,27 @@ If you have bash completion installed, follow the README \
 (https://github.com/pimterry/notes#installing-bash-completion) \
 to manually install it.\n\n"; \
 	fi # Small test for bash completion support
+
 	@install -m755 -d $(PREFIX)/bin/
 	@install -m755 notes $(PREFIX)/bin/
-	@install -m777 -d $(USERDIR)/.config/notes/
-	@install -m777 config $(USERDIR)/.config/notes/
 	@install -d $(PREFIX)/share/man/man1/
 	@install notes.1 $(PREFIX)/share/man/man1/
 
 	@mandb 1>/dev/null 2>&1 || true # Fail silently if we don't have a mandb
 
+	@printf "Notes has been installed to $(PREFIX)/bin/notes.\n"
+
+	@if [ ! -f $(USERDIR)/.config/notes/config ]; then \
+		install -m777 -d $(USERDIR)/.config/notes/; \
+		install -m777 config $(USERDIR)/.config/notes/; \
+		printf \
+"A configuration file has also been created at $(USERDIR)/.config/notes/config, \
+which you can edit if you'd like to change the default settings.\n"; \
+	fi # install default config file if non present
+
 	@printf \
-"Notes has been installed to $(PREFIX)/bin/notes. \
-A configuration file has also been created at $(USERDIR)/.config/notes/config, \
-which you can edit if you'd like to change the default settings.\n\n\
-Get started now by running 'notes new my-note' \
-or you can run 'notes help' for more info.\n"
+"\nGet started now by running 'notes new my-note' \
+or you can run 'notes help' for more info.\n"; \
 
 uninstall:
 	rm -f $(PREFIX)/bin/notes

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 PREFIX ?= /usr/local
-BASH_COMPLETION_DIR := $(shell pkg-config --silence-errors --variable=completionsdir bash-completion) 
-# pkg-config adds a space for some reason, we have to strip it off.
-BASH_COMPLETION_DIR := $(strip $(BASH_COMPLETION_DIR))
+BASH_COMPLETION_DIR := $(shell pkg-config --silence-errors --variable=completionsdir bash-completion)
 USERDIR ?= $(HOME)
 
 # The @ symbols make the output silent.


### PR DESCRIPTION
You can't really notice it with the Github diff but there was a trailing whitespace causing that mentioned issue in the comment (about pkg-config)

During installation, if the config file is already there we should not overwrite it with default values again