### PR TITLE
Add cat command

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Opens a given note in your `$EDITOR`. Name can be an absolute path, or a relativ
 
 Removes the given note if it exists. If `-r` or `--recursive` is given, deletes the folders/notes recursively.
 
+### `notes cat <note-name>`
+
+Displays the note
+
 ### `notes grep/find <pattern> | notes open`
 
 Combine these together! This opens each matching note in your `$EDITOR` in turn.

--- a/_notes
+++ b/_notes
@@ -24,6 +24,7 @@ __notes_cmd ()
     search:'[pattern] Search notes by filename or content'
     open:'<name> Open a notes for editing by full name'
     rm:'[-r | --recursive] <name> Remove note, or folder if -r or --recursive is given]'
+    cat:'<name> Display a note by name'
     --help:'Show usage'
   )
   _describe -t sub-commands 'sub commands' list && _ret=0
@@ -38,7 +39,7 @@ _notes ()
     _alternative 'sub-commands:files:__notes_cmd' && _ret=0
   elif (($CURRENT == 3)); then
     case $words[2] in
-      open|o|rm)
+      open|o|rm|cat)
         _path_files -W "${note_dir}" && _ret=0;;
       new|n|ls)
         _path_files -W "${note_dir}" -/ && _ret=0;;

--- a/notes
+++ b/notes
@@ -167,6 +167,33 @@ open_note() {
     $EDITOR "$note_path" < /dev/tty
 }
 
+cat_something() {
+    if [[ -p /dev/stdin ]]; then
+        read -d'\n' note_names
+        while read note_name; do
+            cat_note "$note_name"
+        done <<< "$note_names"
+    elif [ $# -gt 0 ]; then
+        cat_note "$*"
+    else
+        printf "Cat requires a name, but none was provided."
+        return 1
+    fi
+}
+
+cat_note() {
+    local note_path=$1
+
+    if [[ "$note_path" != *.$NOTES_EXT ]]; then
+        note_path="$note_path.$NOTES_EXT"
+    fi
+    if [ ! -f "$note_path" ]; then
+        note_path="$notes_dir/$note_path"
+    fi
+
+    cat "$note_path"
+}
+
 usage() {
 	cat <<EOF
 notes is a command line note taking tool.
@@ -180,7 +207,9 @@ Usage:
     notes open|o                          # Open your notes directory
     notes open|o <name>                   # Open a note for editing by full name
     notes rm [-r | --recursive] <name>    # Remove note, or folder if -r or --recursive is given
+    notes cat <name>                      # Display note
     echo <name> | notes open|o            # Open all note filenames piped in
+    echo <name> | notes cat               # Display all note filenames piped in
     notes --help                          # Print this usage information
 
 'command|c' means you can use 'command' or the equivalent shorthand alias 'c'
@@ -221,6 +250,9 @@ main() {
             ;;
         "rm" )
             cmd="remove_note"
+            ;;
+        "cat" )
+            cmd="cat_something"
             ;;
         --help | -help | -h )
             cmd="usage"

--- a/notes
+++ b/notes
@@ -137,59 +137,59 @@ remove_note() {
     rm "${rm_args[@]}" "$to_remove"
 }
 
-open_something() {
+handle_multiple_notes() {
+    local cmd=$1
+
     if [[ -p /dev/stdin ]]; then
         read -d'\n' note_names
         while read note_name; do
-            open_note "$note_name"
+            ${cmd}_note "$note_name"
         done <<< "$note_names"
-    elif [ $# -gt 0 ]; then
-        open_note "$*"
     else
-        open $notes_dir
+        ${cmd}_note "${@:2}"
     fi
+}
+
+get_full_note_path() {
+    local note_path=$1
+
+    if [[ "$note_path" != *.$NOTES_EXT ]]; then
+        note_path="$note_path.$NOTES_EXT"
+    fi
+    if [ ! -f "$note_path" ]; then
+        note_path="$notes_dir/$note_path"
+    fi
+
+    echo "$note_path"
 }
 
 open_note() {
     local note_path=$1
 
-    if [[ "$note_path" != *.$NOTES_EXT ]]; then
-        note_path="$note_path.$NOTES_EXT"
+    if [[ -z "$note_path" ]]; then
+        open $notes_dir
+        return
     fi
-    if [ ! -f "$note_path" ]; then
-        note_path="$notes_dir/$note_path"
-    fi
+
     if [ -z "$EDITOR" ]; then
         printf "Please set \$EDITOR to edit notes\n"
         exit 1
     fi
 
-    $EDITOR "$note_path" < /dev/tty
-}
+    note_path=$( get_full_note_path "$note_path" )
 
-cat_something() {
-    if [[ -p /dev/stdin ]]; then
-        read -d'\n' note_names
-        while read note_name; do
-            cat_note "$note_name"
-        done <<< "$note_names"
-    elif [ $# -gt 0 ]; then
-        cat_note "$*"
-    else
-        printf "Cat requires a name, but none was provided."
-        return 1
-    fi
+    $EDITOR "$note_path" < /dev/tty
 }
 
 cat_note() {
     local note_path=$1
 
-    if [[ "$note_path" != *.$NOTES_EXT ]]; then
-        note_path="$note_path.$NOTES_EXT"
+    if [[ -z "$note_path" ]]; then
+        printf "Cat requires a name, but none was provided."
+        exit 1
     fi
-    if [ ! -f "$note_path" ]; then
-        note_path="$notes_dir/$note_path"
-    fi
+
+    note_path=$( get_full_note_path "$note_path" )
 
     cat "$note_path"
 }
@@ -246,13 +246,13 @@ main() {
             cmd="grep_notes"
             ;;
         "open"|"o" )
-            cmd="open_something"
+            cmd="handle_multiple_notes open"
             ;;
         "rm" )
             cmd="remove_note"
             ;;
         "cat" )
-            cmd="cat_something"
+            cmd="handle_multiple_notes cat"
             ;;
         --help | -help | -h )
             cmd="usage"

--- a/notes.1
+++ b/notes.1
@@ -10,7 +10,7 @@ is a simple command line tool that makes note taking simpler.
 When run without a command, the help screen will appear and will offer a brief
 description of availible commands.
 
-\fBnotes\fR will run the default editor for your distribution when opening a 
+\fBnotes\fR will run the default editor for your distribution when opening a
 note. You can set $EDITOR in your shell to override it.
 \fBnotes\fR uses a configuration file located at \fB~/.config/notes/config\fR.
 This file overrides any settings in your rc file.
@@ -32,7 +32,7 @@ Searches the contents of all notes for the given pattern. Returns all matches.
 Combination of find and grep.
 .TP
 .BR ls " " \fR[\fIDIRECTORY\fR]
-Lists all notes within \fIDIRECTORY\fR. Lists contents of $NOTES_DIRECTORY if 
+Lists all notes within \fIDIRECTORY\fR. Lists contents of $NOTES_DIRECTORY if
 no path is provided.
 .TP
 .BR open ", " o
@@ -44,6 +44,10 @@ absolute path or relative to $NOTES_DIRECTORY.
 .TP
 .BR rm " "\fR[\fB\-r\fR | \fB\-\-recursive\fR] " "\fINAME\fR
 Removes \fINAME\fR. If \-r or \-\-recursive is given, folders will be removed.
+.TP
+.BR cat " " \fINAME\fR
+Display note \fINAME\fR. \fINAME\fR can either be an absolute path or relative
+to $NOTES_DIRECTORY.
 .SH AUTHORS
 Notes was created by Tim Perry, who is still the maintainer. Numerous
 contributions have been submitted via pull requests on github.

--- a/notes.bash_completion
+++ b/notes.bash_completion
@@ -16,7 +16,7 @@ _notes_complete_notes() {
 }
 
 _notes_complete_commands() {
-    local valid_commands="new find grep open ls rm"
+    local valid_commands="new find grep open ls rm cat"
     COMPREPLY=($(compgen -W "${valid_commands}" -- "${1}"))
 }
 
@@ -38,6 +38,9 @@ _notes()
             grep)
                 ;;
             open)
+                _notes_complete_notes "$cur"
+                ;;
+            cat)
                 _notes_complete_notes "$cur"
                 ;;
         esac

--- a/test/test-cat.bats
+++ b/test/test-cat.bats
@@ -1,0 +1,75 @@
+#!./test/libs/bats/bin/bats
+
+load 'libs/bats-support/load'
+load 'libs/bats-assert/load'
+load 'helpers'
+
+setup() {
+  setupNotesEnv
+}
+
+teardown() {
+  teardownNotesEnv
+}
+
+notes="./notes"
+
+@test "Should show created note" {
+  echo line1 >> "$NOTES_DIRECTORY/note.md"
+  echo line2 >> "$NOTES_DIRECTORY/note.md"
+  run $notes cat note.md
+
+  assert_success
+  assert_output $'line1\nline2'
+}
+
+@test "Accepts names without .md to show" {
+  echo line1 >> "$NOTES_DIRECTORY/note.md"
+  echo line2 >> "$NOTES_DIRECTORY/note.md"
+  run $notes cat note
+
+  assert_success
+  assert_output $'line1\nline2'
+}
+
+@test "Should fail to show non-existent note" {
+  run $notes cat note
+
+  assert_failure
+}
+
+@test "Accepts relative notes paths to show" {
+  echo line1 >> "$NOTES_DIRECTORY/note.md"
+  echo line2 >> "$NOTES_DIRECTORY/note.md"
+  run $notes cat $NOTES_DIRECTORY/note.md
+
+  assert_success
+  assert_output $'line1\nline2'
+}
+
+@test "Show a file passed by pipe from find" {
+  echo line1 >> "$NOTES_DIRECTORY/note.md"
+  echo line2 >> "$NOTES_DIRECTORY/note.md"
+
+  run bash -c "$notes find | $notes cat"
+
+  assert_success
+  assert_output $'line1\nline2'
+}
+
+@test "Show multiple files passed by pipe from find" {
+  echo line1 >> "$NOTES_DIRECTORY/note.md"
+  echo line2 >> "$NOTES_DIRECTORY/note2.md"
+
+  run bash -c "$notes find | $notes cat"
+
+  assert_success
+  assert_output $'line1\nline2'
+}
+
+@test "Should complain and ask for a name if one is not provided to show" {
+  run $notes cat
+
+  assert_failure
+  assert_line "Cat requires a name, but none was provided."
+}


### PR DESCRIPTION
There are some types of notes which are meant to be viewed most of time and edited only rarely
It's inconvenient to have to open an editor just to see them so I've added this show command to display the content of a note in the standard output

I believe everything needed is there: code, completion, test, doc
I have made to play nicely with pipes like the open command