### PR TITLE
Fix autocompletion in case of non default notes directory

### DIFF
--- a/_notes
+++ b/_notes
@@ -31,6 +31,11 @@ __notes_cmd ()
 
 _notes ()
 {
+  # Look for configuration file at ~/.config/notes/config and use it
+  if [ -f ~/.config/notes/config ]; then
+      . ~/.config/notes/config
+  fi
+
   local configured_dir=${NOTES_DIRECTORY%/}
   local note_dir="${configured_dir:-$HOME/notes}"
 

--- a/config
+++ b/config
@@ -1,4 +1,4 @@
-# This is an example configuration file for notes 
+# This is an example configuration file for notes
 # To use it, copy to ~/.config/notes/config
 # This config is case sensitive
 
@@ -9,4 +9,7 @@
 # QUICKNOTE_FORMAT="%Y-%m-%d"
 
 # Set extension to plain txt instead of markdown
-#NOTES_EXT="txt"
+# NOTES_EXT="txt"
+
+# Define the directory where notes are stored
+# NOTES_DIRECTORY=~/notes

--- a/notes.bash_completion
+++ b/notes.bash_completion
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 _notes_complete_notes() {
+    # Look for configuration file at ~/.config/notes/config and use it
+    if [ -f ~/.config/notes/config ]; then
+        . ~/.config/notes/config
+    fi
+
     local configured_dir=${NOTES_DIRECTORY%/} # Remove trailing slashes
     local notes_dir="${configured_dir:-$HOME/notes}"
     local OLD_IFS="$IFS"


### PR DESCRIPTION
The autocompletion were broken and not showing the notes name because the NOTES_DIRECTORY variable was always empty. It was only working if one had this variable exported in the shell, or if using the default notes location

I've also added this variable in the default config file to make it easier for people to know of its existence