### PR TITLE
Fix recursive remove with no arguments deleting entire notes directory

### DIFF
--- a/notes
+++ b/notes
@@ -124,8 +124,18 @@ new_note() {
 remove_note() {
     local rm_args=()
     if [[ "$1" == "-r" || "$1" == "--recursive" ]]; then
-        rm_args+=("--recursive")
+        # checks for macos, as it doesn't support long arguments for rm
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            rm_args+=("-r")
+        else
+            rm_args+=("--recursive")
+        fi
         shift
+    fi
+
+    if [ ! "$#" -gt 0 ]; then
+        printf "Remove requires a file or folder, but none was provided."
+        return 1
     fi
 
     local note_name="$*"
@@ -270,3 +280,4 @@ main() {
     exit $ret
 }
 main "$@"
+

--- a/notes
+++ b/notes
@@ -167,7 +167,7 @@ open_note() {
     local note_path=$1
 
     if [[ -z "$note_path" ]]; then
-        open $notes_dir
+        open "$notes_dir"
         return
     fi
 

--- a/test/test-rm.bats
+++ b/test/test-rm.bats
@@ -28,6 +28,12 @@ notes="./notes"
   assert_failure
 }
 
+@test "Should fail when no file or folder given" {
+  run $notes rm
+
+  assert_failure
+}
+
 @test "Should remove note in folder" {
   mkdir "$NOTES_DIRECTORY/folder"
   touch "$NOTES_DIRECTORY/folder/note.md"
@@ -52,7 +58,18 @@ notes="./notes"
 
   assert_success
   refute_exists "$NOTES_DIRECTORY/folder"
-  refute_exists "$NOTES_DIRECTORY/folder/notes.md"
+  refute_exists "$NOTES_DIRECTORY/folder/note.md"
+}
+
+@test "-r Should fail if no file or folder given" {
+  mkdir "$NOTES_DIRECTORY/folder"
+  touch "$NOTES_DIRECTORY/folder/note.md"
+  run $notes rm -r
+
+  assert_failure
+  assert_line "Remove requires a file or folder, but none was provided."
+  assert_exists "$NOTES_DIRECTORY/folder"
+  assert_exists "$NOTES_DIRECTORY/folder/note.md"
 }
 
 @test "--recursive Should remove folder recursively" {
@@ -62,7 +79,18 @@ notes="./notes"
 
   assert_success
   refute_exists "$NOTES_DIRECTORY/folder"
-  refute_exists "$NOTES_DIRECTORY/folder/notes.md"
+  refute_exists "$NOTES_DIRECTORY/folder/note.md"
+}
+
+@test "--recursive Should fail if no file or folder given" {
+  mkdir "$NOTES_DIRECTORY/folder"
+  touch "$NOTES_DIRECTORY/folder/note.md"
+  run $notes rm --recursive
+
+  assert_failure
+  assert_line "Remove requires a file or folder, but none was provided."
+  assert_exists "$NOTES_DIRECTORY/folder"
+  assert_exists "$NOTES_DIRECTORY/folder/note.md"
 }
 
 @test "should delete file if both folder and file exists" {


### PR DESCRIPTION
I discovered that calling `note rm -r` or `note rm --recursive` **without** passing a file or folder will recursively delete the entire notes directory (mine were backed up, of course).

This fix just adds a simple check to see if there is an argument passed. Very similar to the checks already used in the grep and cat functions.

The tests were failing on MacOS as `rm --recursive` isn't supported, so I added a check when creating the recursive flag.

I added further tests for the above recursive remove fix.

I also snuck in a tiny fix to handle directory names with spaces (thanks, Google Drive).