### PR TITLE
exit 1  on failure to create NOTES_DIRECTORY

### DIFF
--- a/notes
+++ b/notes
@@ -13,13 +13,10 @@ notes_dir="${configured_dir:-$HOME/notes}"
 escaped_notes_dir="$(printf "$notes_dir" | sed -e 's/[]\/$*.^|[]/\\&/g')"
 
 # Make sure the notes directory actually exists, and create it if it doesn't
-# if [ ! -d "$notes_dir" ]; then
-# mkdir man page says "create the Dir(s) if they donot already exist"
 if ! $(mkdir -p "$notes_dir"); then
-    echo "please, set \$NOTES_DIRECTORY to a different location" >&2
+    echo "Could not create directory $notes_dir, please update your \$NOTES_DIRECTORY" >&2
     exit 1
 fi
-# fi
 
 # If no $EDITOR, look for `editor` (symlink on debian/ubuntu/etc)
 if [ -z "$EDITOR" ] && type editor &>/dev/null; then

--- a/notes
+++ b/notes
@@ -13,9 +13,13 @@ notes_dir="${configured_dir:-$HOME/notes}"
 escaped_notes_dir="$(printf "$notes_dir" | sed -e 's/[]\/$*.^|[]/\\&/g')"
 
 # Make sure the notes directory actually exists, and create it if it doesn't
-if [ ! -d "$notes_dir" ]; then
-    mkdir -p "$notes_dir"
+# if [ ! -d "$notes_dir" ]; then
+# mkdir man page says "create the Dir(s) if they donot already exist"
+if ! $(mkdir -p "$notes_dir"); then
+    echo "set \$NOTES_DIRECTORY to a different location" >&2
+    exit 1
 fi
+# fi
 
 # If no $EDITOR, look for `editor` (symlink on debian/ubuntu/etc)
 if [ -z "$EDITOR" ] && type editor &>/dev/null; then

--- a/notes
+++ b/notes
@@ -16,7 +16,7 @@ escaped_notes_dir="$(printf "$notes_dir" | sed -e 's/[]\/$*.^|[]/\\&/g')"
 # if [ ! -d "$notes_dir" ]; then
 # mkdir man page says "create the Dir(s) if they donot already exist"
 if ! $(mkdir -p "$notes_dir"); then
-    echo "set \$NOTES_DIRECTORY to a different location" >&2
+    echo "please, set \$NOTES_DIRECTORY to a different location" >&2
     exit 1
 fi
 # fi

--- a/test/test-config.bats
+++ b/test/test-config.bats
@@ -42,3 +42,21 @@ notes="./notes"
   assert_success
   assert_exists "$NOTES_DIRECTORY/test.txt"
 }
+
+@test "Configuration should be accepted if NOTES_DIR doesn't exist" {
+  mkdir -p $HOME/.config/notes
+  echo "NOTES_DIRECTORY=$NOTES_DIRECTORY/notesdir" > $HOME/.config/notes/config
+  run $notes new test
+
+  assert_success
+}
+
+@test "Configuration should be rejected if NOTES_DIR is a existing file" {
+  mkdir -p $HOME/.config/notes
+  touch $NOTES_DIRECTORY/testfile
+  echo "NOTES_DIRECTORY=$NOTES_DIRECTORY/testfile" > $HOME/.config/notes/config
+  run $notes new test
+
+  assert_failure
+  assert_line "Could not create directory $NOTES_DIRECTORY/testfile, please update your \$NOTES_DIRECTORY"
+}


### PR DESCRIPTION
<!--
Thank you for contributing to notes, before you publish your pull request, please follow this template to make sure your PR fits the criteria. 


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 
Fixes #55 
Closes #55 

### Checklist
- [x] I have made a change to this repository, be it functionality, testing, documentation, spelling, or grammar.
- [x] I updated my branch with the master branch.
- [ ] I have added the necessary testing to prove my fix is effective or my feature work, or I did not modify functionality.
- [ ] I have added necessary documentation about the functionality in an appropriate .md file
- [x] I have commented any code I have modified or I did not modify any code

### Short description of what this PR does:
- When `mkdir` fails create NOTES_DIRECTORY, it exits with 
an error message to user
