### PR TITLE
Move repeated import: bats-assert and bats-support to helper file

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,3 +1,6 @@
+load 'libs/bats-support/load'
+load 'libs/bats-assert/load'
+
 assert_exists() {
   assert [ -e "$1" ]
 }

--- a/test/test-base.bats
+++ b/test/test-base.bats
@@ -1,7 +1,5 @@
 #!./test/libs/bats/bin/bats
 
-load 'libs/bats-support/load'
-load 'libs/bats-assert/load'
 load 'helpers'
 
 setup() {

--- a/test/test-bash-completion.bats
+++ b/test/test-bash-completion.bats
@@ -1,7 +1,5 @@
 #!./test/libs/bats/bin/bats
 
-load 'libs/bats-support/load'
-load 'libs/bats-assert/load'
 load 'helpers'
 
 setup() {

--- a/test/test-cat.bats
+++ b/test/test-cat.bats
@@ -1,7 +1,5 @@
 #!./test/libs/bats/bin/bats
 
-load 'libs/bats-support/load'
-load 'libs/bats-assert/load'
 load 'helpers'
 
 setup() {

--- a/test/test-config.bats
+++ b/test/test-config.bats
@@ -1,7 +1,5 @@
 #!./test/libs/bats/bin/bats
 
-load 'libs/bats-support/load'
-load 'libs/bats-assert/load'
 load 'helpers'
 
 setup() {

--- a/test/test-find.bats
+++ b/test/test-find.bats
@@ -1,7 +1,5 @@
 #!./test/libs/bats/bin/bats
 
-load 'libs/bats-support/load'
-load 'libs/bats-assert/load'
 load 'helpers'
 
 setup() {

--- a/test/test-grep.bats
+++ b/test/test-grep.bats
@@ -1,7 +1,5 @@
 #!./test/libs/bats/bin/bats
 
-load 'libs/bats-support/load'
-load 'libs/bats-assert/load'
 load 'helpers'
 
 setup() {

--- a/test/test-help.bats
+++ b/test/test-help.bats
@@ -1,7 +1,5 @@
 #!./test/libs/bats/bin/bats
 
-load 'libs/bats-support/load'
-load 'libs/bats-assert/load'
 load 'helpers'
 
 setup() {

--- a/test/test-ls.bats
+++ b/test/test-ls.bats
@@ -1,7 +1,5 @@
 #!./test/libs/bats/bin/bats
 
-load 'libs/bats-support/load'
-load 'libs/bats-assert/load'
 load 'helpers'
 
 setup() {

--- a/test/test-new.bats
+++ b/test/test-new.bats
@@ -1,7 +1,5 @@
 #!./test/libs/bats/bin/bats
 
-load 'libs/bats-support/load'
-load 'libs/bats-assert/load'
 load 'helpers'
 
 setup() {

--- a/test/test-open.bats
+++ b/test/test-open.bats
@@ -1,7 +1,5 @@
 #!./test/libs/bats/bin/bats
 
-load 'libs/bats-support/load'
-load 'libs/bats-assert/load'
 load 'helpers'
 
 function open() { echo "Opening $*"; }

--- a/test/test-rm.bats
+++ b/test/test-rm.bats
@@ -1,7 +1,5 @@
 #!./test/libs/bats/bin/bats
 
-load 'libs/bats-support/load'
-load 'libs/bats-assert/load'
 load 'helpers'
 
 setup() {

--- a/test/test-search.bats
+++ b/test/test-search.bats
@@ -1,7 +1,5 @@
 #!./libs/bats/bin/bats
 
-load 'libs/bats-support/load'
-load 'libs/bats-assert/load'
 load 'helpers'
 
 setup() {


### PR DESCRIPTION
Hoping the change is helpful. 🙂

### Checklist
- [x] I have made a change to this repository, be it functionality, testing, documentation, spelling, or grammar.
- [x] I updated my branch with the master branch.
- [x] I have added the necessary testing to prove my fix is effective/my feature works (or I did not modify functionality).
- [x] I have added necessary documentation about the functionality in an appropriate .md file.
- [x] I have appropriately commented any code I have modified

### Short description of what this PR does:
- Loads bats-support and bats-assert in helper file.
- Easier for future development but less explicit and the same overhead.

### Thanks, this project helped me set up bats-assert for my project 💯.