### PR TITLE
fix autocompletion for short commands

### DIFF
--- a/notes.bash_completion
+++ b/notes.bash_completion
@@ -21,7 +21,7 @@ _notes_complete_notes() {
 }
 
 _notes_complete_commands() {
-    local valid_commands="new find grep open ls rm cat"
+    local valid_commands="new find grep open ls rm cat search"
     COMPREPLY=($(compgen -W "${valid_commands}" -- "${1}"))
 }
 
@@ -34,18 +34,18 @@ _notes()
 
     if [[ $COMP_CWORD -gt 1 ]]; then
         case "${COMP_WORDS[1]}" in
-            new)
+            new|n)
                 _notes_complete_notes "$cur"
                 ;;
-            find)
+            find|f)
                 _notes_complete_notes "$cur"
                 ;;
             grep)
                 ;;
-            open)
+            open|o)
                 _notes_complete_notes "$cur"
                 ;;
-            cat)
+            cat|c)
                 _notes_complete_notes "$cur"
                 ;;
         esac

--- a/notes.bash_completion
+++ b/notes.bash_completion
@@ -48,6 +48,9 @@ _notes()
             cat|c)
                 _notes_complete_notes "$cur"
                 ;;
+            ls)
+                _notes_complete_notes "$cur"
+                ;;
         esac
     else
         compopt +o nospace

--- a/test/test-bash-completion.bats
+++ b/test/test-bash-completion.bats
@@ -21,6 +21,7 @@ teardown() {
   assert_contains "open" "${COMPREPLY[@]}"
   assert_contains "ls"   "${COMPREPLY[@]}"
   assert_contains "rm"   "${COMPREPLY[@]}"
+  assert_contains "search" "${COMPREPLY[@]}"
 }
 
 @test "Should show matching note when found" {


### PR DESCRIPTION
<!--
Thank you for contributing to notes, before you submit your pull request, please follow this template to make sure your PR fits the criteria. 

Please enter each issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes #38 

### Checklist
- [x] I have made a change to this repository, be it functionality, testing, documentation, spelling, or grammar.
- [x] I updated my branch with the master branch.
- [ ] I have added the necessary testing to prove my fix is effective/my feature works (or I did not modify functionality).
- [ ] I have added necessary documentation about the functionality in an appropriate .md file.
- [ ] I have appropriately commented any code I have modified

### Short description of what this PR does:
- The short commands do not autocomplete file names. e.g. `notes o <tab><tab>` does not yield the files in your `$NOTES_DIRECTORY`. This PR adds that autocompletion.
- The `search` and `ls` commands were omitted from the autocomplete. This has been added and is covered by the unit tests.

I wasn't sure if this needs extra unit tests. Let me know what you think!