### PR TITLE
Ensure consistent order of find/grep/search results

### DIFF
--- a/notes
+++ b/notes
@@ -62,7 +62,7 @@ search_filenames_and_contents() {
         find_output=$(find "$notes_dir" -type f)
     fi
     find_result=$?
-    formatted_output=$(printf "$find_output" | without_notes_dir)
+    formatted_output=$(printf "$find_output" | without_notes_dir | sort)
 
     if [[ $find_result == 0 && "$formatted_output" ]]; then
         printf "$formatted_output\n"
@@ -75,7 +75,7 @@ search_filenames_and_contents() {
 find_notes() {
     local find_output=$(find "$notes_dir" -ipath "$notes_dir/*$**" -type f 2>&1)
     local find_result=$?
-    local formatted_output=$(printf "$find_output" | without_notes_dir)
+    local formatted_output=$(printf "$find_output" | without_notes_dir | sort)
 
     if [[ $find_result == 0 && "$formatted_output" ]]; then
         printf "$formatted_output\n"
@@ -93,7 +93,7 @@ grep_notes() {
 
     local grep_output=$(grep -r "$notes_dir" -li -e "$*" 2>&1)
     local grep_result=$?
-    local formatted_output=$(printf "$grep_output" | without_notes_dir)
+    local formatted_output=$(printf "$grep_output" | without_notes_dir | sort)
 
     if [[ $grep_result == 0 && "$formatted_output" ]]; then
         printf "$formatted_output\n"

--- a/test/test-cat.bats
+++ b/test/test-cat.bats
@@ -56,7 +56,7 @@ notes="./notes"
 }
 
 @test "Show multiple files passed by pipe from find" {
-  echo line1 >> "$NOTES_DIRECTORY/note.md"
+  echo line1 >> "$NOTES_DIRECTORY/note1.md"
   echo line2 >> "$NOTES_DIRECTORY/note2.md"
 
   run bash -c "$notes find | $notes cat"


### PR DESCRIPTION
Fixes #72 

Based on [your comment](https://github.com/pimterry/notes/issues/72#issuecomment-526317557) @primis, I think this is simply non-deterministic: on my machine it seems to fail when running the commands manually or through the test suite, even though it used to work.

I propose we start just explicitly sorting results, which makes this test pass (on Travis & my machine at least, and in theory everywhere), and seems like a nice & sensible thing to do anyway. What do you think?