### PR TITLE
Make `ls` ignore vim backup files

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Searches all note content and note filenames for the given string and returns al
 
 ### `notes ls <directory>`
 
-Lists note names and note directories at a single level. Lists all top level notes and directories if no path is provided, or the top-level contents of a directory if one is provided.
+Lists note names and note directories at a single level. Lists all top level notes and directories if no path is provided, or the top-level contents of a directory if one is provided. Automatically ignores hidden files or filenames ending with `~` (Vim backup files).
 
 ### `notes open`
 

--- a/notes
+++ b/notes
@@ -31,7 +31,7 @@ without_notes_dir() {
 }
 
 ls_notes() {
-    local ls_output=$(ls -p "$notes_dir/$*" -I "*~" 2>&1)
+    local ls_output=$(ls -p "$notes_dir/$*" 2>&1 | grep -v "~$")
     local ls_result=$?
     local formatted_output
 

--- a/notes
+++ b/notes
@@ -31,7 +31,7 @@ without_notes_dir() {
 }
 
 ls_notes() {
-    local ls_output=$(ls -p "$notes_dir/$*" 2>&1)
+    local ls_output=$(ls -p "$notes_dir/$*" -I "*~" 2>&1)
     local ls_result=$?
     local formatted_output
 

--- a/test/test-ls.bats
+++ b/test/test-ls.bats
@@ -30,6 +30,20 @@ notes="./notes"
   assert_line "note2.md"
 }
 
+@test "Should not list temporary files" {
+  touch $NOTES_DIRECTORY/note1.md
+  touch $NOTES_DIRECTORY/note1.md~
+  touch $NOTES_DIRECTORY/note2~with~tilde.md
+
+  run $notes ls
+  assert_success
+
+  assert_line "note1.md"
+  assert_line "note2~with~tilde.md"
+
+  refute_line "note1.md~"
+}
+
 @test "Should list subdirectories with trailing slash" {
   touch $NOTES_DIRECTORY/match-note1.md
   mkdir $NOTES_DIRECTORY/match-dir


### PR DESCRIPTION
<!--
Thank you for contributing to notes, before you submit your pull request, please follow this template to make sure your PR fits the criteria. 

Please enter each issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I have made a change to this repository, be it functionality, testing, documentation, spelling, or grammar.
- [x] I updated my branch with the master branch.
- [ ] I have added the necessary testing to prove my fix is effective/my feature works (or I did not modify functionality).
- [ ] I have added necessary documentation about the functionality in an appropriate .md file.
- [ ] I have appropriately commented any code I have modified

### Short description of what this PR does:
In case user has vim set up to create backup files in the current directory, make the `ls` command ignore backup files (ending in '~' by default).

I find this helpful with my setup, but it obviously won't be of benefit to everyone. Probably won't cause any problems, though. I don't imagine anyone uses '~' at the end of a filename for any other purpose (and for some reason, also stores them in the notes directory).

Yeah, take it or leave it. :-) 
