### PR TITLE
Add support for explicit file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Opens your notes folder in your default configured file explorer. Shorthand alia
 
 Opens a given note in your `$EDITOR`. Name can be an absolute path, or a relative path in your notes (.md suffix optional). Shorthand alias also available with `notes o`.
 
-If not file-suffix is given in `note-name`, the notes will attempt to open `note-name.md` (or whatever your default suffix is set to). However, if the note-name is given an suffix, the default suffix will not be appended (e.g. `notes open note-name.txt` will open `note-name.txt`; not `note-name.md` or `note-name.txt.md`).
+If no file-suffix is given in `note-name`, the notes will attempt to open `note-name.md` (or whatever your default suffix is set to). However, if the note-name is given an suffix, the default suffix will not be appended (e.g. `notes open note-name.txt` will open `note-name.txt`; not `note-name.md` or `note-name.txt.md`).
 
 ### `notes mv <note-name> <destination>|<directory>`
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ There are also more complex options available. You can set any configuration pro
 
 Opens your `$EDITOR` of choice for a new note, with the given name. The name can include slashes, if you want to put your note in a subfolder. Leave out the name if you want one to be generated for you (e.g. `quicknote-2016-12-21.md` - format configurable with `$QUICKNOTE_FORMAT`). If you want to place a quicknote in a subfolder, use a trailing slash: `notes new subfolder/`. Shorthand alias also available with `notes n`.
 
+If you do not supply an extension in `note-name`, it will be automatically appended with the default file extension (e.g. "newnote" will become "newnote.md"). However, if you include a one-to-four-letter file extension, notes will use that extension when creating the file (e.g. "newnote.tex" is created as "newnote.tex"; not "newnote.md", or "newnote.tex.md").
+
 ### `notes find <part-of-a-note-name>`
 
 Searches note filenames and paths for the given string, and returns every single match. If no pattern is specified, this returns every single note. Shorthand alias also available with `notes f`.
@@ -128,6 +130,8 @@ Opens your notes folder in your default configured file explorer. Shorthand alia
 ### `notes open <note-name>`
 
 Opens a given note in your `$EDITOR`. Name can be an absolute path, or a relative path in your notes (.md suffix optional). Shorthand alias also available with `notes o`.
+
+If not file-suffix is given in `note-name`, the notes will attempt to open `note-name.md` (or whatever your default suffix is set to). However, if the note-name is given an suffix, the default suffix will not be appended (e.g. `notes open note-name.txt` will open `note-name.txt`; not `note-name.md` or `note-name.txt.md`).
 
 ### `notes mv <note-name> <destination>|<directory>`
 

--- a/notes
+++ b/notes
@@ -151,7 +151,8 @@ remove_note() {
     local note_name="$*"
     local to_remove="$notes_dir/$note_name"
 
-    if [ -f "$notes_dir/$note_name.$NOTES_EXT" ]; then
+    if [ ! -f "$to_remove" ] && [ -f "$notes_dir/$note_name.$NOTES_EXT" ]; then
+        # append default extension only if no file exists with exact filename given
         to_remove="$notes_dir/$note_name.$NOTES_EXT"
     fi
     rm "${rm_args[@]}" "$to_remove"

--- a/notes
+++ b/notes
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Version
-notes_version="0.5.2"
+notes_version="0.5.3"
 
 # Default Date string before config
 QUICKNOTE_FORMAT="quicknote-%Y-%m-%d"

--- a/notes
+++ b/notes
@@ -174,11 +174,13 @@ get_full_note_path() {
     local note_path=$1
 
     # first check if file exists
-    if [ -f "$note_path" ]; then # note path given is good
+    if [ -f "$note_path" ]; then # note path given is good absolute or relative path
         note_path="$note_path"
-    elif [ -f "$notes_dir/$note_path" ]; then # exists
+    elif [ -f "$notes_dir/$note_path" ]; then # exists in notes_dir
         note_path="$notes_dir/$note_path"
-    elif echo "$note_path" | grep '[.][A-Za-z]\{1,4\}$' &>/dev/null; then # has a 1-4 letter extension
+    elif [ -f "$notes_dir/$note_path.$NOTES_EXT" ]; then # note with this name and default extension exists
+        note_path="$notes_dir/$note_path.$NOTES_EXT"
+    elif echo "$note_path" | grep '[.][A-Za-z]\{1,4\}$' &>/dev/null; then # given name has a 1-4 letter extension
         note_path="$notes_dir/$note_path"
     else
         if [[ "$note_path" != *.$NOTES_EXT ]]; then

--- a/notes
+++ b/notes
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Version
-notes_version="0.5.3"
+notes_version="0.5.2"
 
 # Default Date string before config
 QUICKNOTE_FORMAT="quicknote-%Y-%m-%d"
@@ -173,10 +173,17 @@ handle_multiple_notes() {
 get_full_note_path() {
     local note_path=$1
 
-    if [[ "$note_path" != *.$NOTES_EXT ]]; then
-        note_path="$note_path.$NOTES_EXT"
-    fi
-    if [ ! -f "$note_path" ]; then
+    # first check if file exists
+    if [ -f "$note_path" ]; then # note path given is good
+        note_path="$note_path"
+    elif [ -f "$notes_dir/$note_path" ]; then # exists
+        note_path="$notes_dir/$note_path"
+    elif echo "$note_path" | grep '[.][A-Za-z]\{1,4\}$' &>/dev/null; then # has a 1-4 letter extension
+        note_path="$notes_dir/$note_path"
+    else
+        if [[ "$note_path" != *.$NOTES_EXT ]]; then
+            note_path="$note_path.$NOTES_EXT"
+        fi
         note_path="$notes_dir/$note_path"
     fi
 

--- a/test/test-new.bats
+++ b/test/test-new.bats
@@ -79,3 +79,10 @@ notes="./notes"
   assert_success
   assert_exists "$NOTES_DIRECTORY/subfolder/quicknote-$today.md"
 }
+
+@test "Should use explicitly named file extensions" {
+  run $notes new explicit-ext.zzz
+
+  assert_success
+  assert_exists "$NOTES_DIRECTORY/explicit-ext.zzz"
+}

--- a/test/test-open.bats
+++ b/test/test-open.bats
@@ -123,3 +123,12 @@ notes="./notes"
   assert_failure
   assert_output "Please set \$EDITOR to edit notes"
 }
+
+@test "Accepts names with other file extensions to open" {
+  touch $NOTES_DIRECTORY/test-note.txt
+
+  run bash -c "$notes open test-note.txt"
+
+  assert_success
+  assert_output "Editing $NOTES_DIRECTORY/test-note.txt"
+}


### PR DESCRIPTION
<!--
Thank you for contributing to notes, before you submit your pull request, please follow this template to make sure your PR fits the criteria. 

Please enter each issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #82 
-->
Fixes #82 
Closes #82 

### Checklist
- [x] I have made a change to this repository, be it functionality, testing, documentation, spelling, or grammar.
- [x] I updated my branch with the master branch.
- [x] I have added the necessary testing to prove my fix is effective/my feature works (or I did not modify functionality).
- [x] I have added necessary documentation about the functionality in an appropriate .md file.
- [x] I have appropriately commented any code I have modified

### Short description of what this PR does:
Allows notes to accept explicit file extensions other than the default in note filenames. 
- 
