### PR TITLE
New command: `realpath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ Displays the note. Shorthand alias also available with `notes c`.
 
 Combine these together! This opens each matching note in your `$EDITOR` in turn.
 
+### `notes realpath [note-name]`
+
+Displays the path to the note name, if provided. Displays the root path to all notes otherwise.
+
 ## Tell me of the future
 
 All the above works. Here's what's coming next:

--- a/notes
+++ b/notes
@@ -314,6 +314,18 @@ cat_note() {
     cat "$note_path"
 }
 
+realpath() {
+    local note_path=$1
+
+    if [[ -z "$note_path" ]]; then
+        note_path=$notes_dir
+    else
+        note_path=$( get_full_note_path "$note_path" )
+    fi
+
+    echo "$note_path"
+}
+
 usage() {
   local name=$(basename $0)
 	cat <<EOF
@@ -331,6 +343,7 @@ Usage:
     $name mv <source> <dest>|<directory>  # Rename a note, or move a note when a directory is given
     $name rm [-r | --recursive] <name>    # Remove note, or folder if -r or --recursive is given
     $name cat|c <name>                    # Display note
+    $name realpath [name]                 # Display full path of note, or notes directory if no name is given
     echo <name> | $name open|o            # Open all note filenames piped in
     echo <name> | $name cat               # Display all note filenames piped in
     $name --help                          # Print this usage information
@@ -396,6 +409,9 @@ main() {
             ;;
         "cat" | "c" )
             cmd="handle_multiple_notes cat"
+            ;;
+        "realpath" )
+            cmd="realpath"
             ;;
         --help | -help | -h )
             cmd="usage"

--- a/notes
+++ b/notes
@@ -317,9 +317,10 @@ cat_note() {
 realpath() {
     local note_path=$1
 
+    # If no note name was provided, return notes directory
     if [[ -z "$note_path" ]]; then
         note_path=$notes_dir
-    else
+    else # otherwise, get full path of note
         note_path=$( get_full_note_path "$note_path" )
     fi
 

--- a/test/test-realpath.bats
+++ b/test/test-realpath.bats
@@ -10,6 +10,7 @@ teardown() {
   teardownNotesEnv
 }
 
+export EDITOR=touch
 notes="./notes"
 
 @test "realpath should return notes_dir without a filename" {

--- a/test/test-realpath.bats
+++ b/test/test-realpath.bats
@@ -1,0 +1,35 @@
+#!./test/libs/bats/bin/bats
+
+load 'helpers'
+
+setup() {
+  setupNotesEnv
+}
+
+teardown() {
+  teardownNotesEnv
+}
+
+notes="./notes"
+
+@test "realpath should return notes_dir without a filename" {
+  run $notes realpath
+
+  assert_success
+  assert_output "$NOTES_DIRECTORY"
+}
+
+@test "realpath of non-existing notes should return the future path to the file" {
+  run $notes realpath note
+
+  assert_success
+  assert_output "$NOTES_DIRECTORY/note.md"
+}
+
+@test "realpath of any existing note should return the path to the file" {
+  run $notes new note
+  run $notes realpath note
+
+  assert_success
+  assert_output "$NOTES_DIRECTORY/note.md"
+}


### PR DESCRIPTION
<!--
Thank you for contributing to notes, before you submit your pull request, please follow this template to make sure your PR fits the criteria. 

Please enter each issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Resolves #93 
# Closes #92 

### Checklist
- [x] I have made a change to this repository, be it functionality, testing, documentation, spelling, or grammar.
- [x] I updated my branch with the master branch.
- [x] I have added the necessary testing to prove my fix is effective/my feature works (or I did not modify functionality).
- [x] I have added necessary documentation about the functionality in an appropriate .md file.
- [x] I have appropriately commented any code I have modified

### Short description of what this PR does:
- A new command `realpath` is added to echo the path to the a note by the name provided. 
- If no note was provided, `realpath` would echo `$NOTES_DIRECTORY`.
- If a note which does not exist was provided, `realpath` would echo the future path to that file.
- As a consequence, A user can run `cd "$(notes realpath)"` to `cd` into `$NOTES_DIRECTORY`.
